### PR TITLE
refactor: replace nuxt ui pro with nuxt ui

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
-# Production license for @nuxt/ui-pro, get one at https://ui.nuxt.com/pro/purchase
-NUXT_UI_PRO_LICENSE=
 # Public URL, used for OG Image when running nuxt generate
 NUXT_PUBLIC_SITE_URL= 'http://localhost/EduHub/eduhub-backend/public'
 NUXT_API_BASE_URL='http://localhost/EduHub/eduhub-backend/public/api'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Nuxt Dashboard Template
 
-[![Nuxt UI Pro](https://img.shields.io/badge/Made%20with-Nuxt%20UI%20Pro-00DC82?logo=nuxt&labelColor=020420)](https://ui.nuxt.com/pro)
-[![Deploy to NuxtHub](https://img.shields.io/badge/Deploy%20to-NuxtHub-00DC82?logo=nuxt&labelColor=020420)](https://hub.nuxt.com/new?repo=nuxt-ui-pro/dashboard)
+[![Nuxt UI](https://img.shields.io/badge/Made%20with-Nuxt%20UI-00DC82?logo=nuxt&labelColor=020420)](https://ui.nuxt.com)
+[![Deploy to NuxtHub](https://img.shields.io/badge/Deploy%20to-NuxtHub-00DC82?logo=nuxt&labelColor=020420)](https://hub.nuxt.com/new?repo=nuxt/ui)
 
-Get started with the Nuxt dashboard template with multiple pages, collapsible sidebar, keyboard shortcuts, light & dark more, command palette and more, powered by [Nuxt UI Pro](https://ui.nuxt.com/pro).
+Get started with the Nuxt dashboard template with multiple pages, collapsible sidebar, keyboard shortcuts, light & dark mode, command palette and more, powered by [Nuxt UI](https://ui.nuxt.com).
 
 - [Live demo](https://dashboard-template.nuxt.dev/)
-- [Documentation](https://ui.nuxt.com/getting-started/installation/pro/nuxt)
+- [Documentation](https://ui.nuxt.com/getting-started/installation/nuxt)
 
 <a href="https://dashboard-template.nuxt.dev/" target="_blank">
   <picture>
@@ -18,12 +18,12 @@ Get started with the Nuxt dashboard template with multiple pages, collapsible si
 
 ## Vue Dashboard Template
 
-The dashboard template for Vue is on https://github.com/nuxt-ui-pro/dashboard-vue.
+The dashboard template for Vue is on https://github.com/nuxt/ui.
 
 ## Quick Start
 
 ```bash [Terminal]
-npx nuxi@latest init -t github:nuxt-ui-pro/dashboard
+npx nuxi@latest init -t github:nuxt/ui
 ```
 
 ## Setup
@@ -61,4 +61,3 @@ Check out the [deployment documentation](https://nuxt.com/docs/getting-started/d
 ## Renovate integration
 
 Install [Renovate GitHub app](https://github.com/apps/renovate/installations/select_target) on your repository and you are good to go.
-# nuxt-ui

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,5 +1,5 @@
 @import "tailwindcss" theme(static);
-@import "@nuxt/ui-pro";
+@import "@nuxt/ui";
 
 @theme static {
   --font-sans: 'Public Sans', sans-serif;

--- a/app/components/UDashboardGroup.vue
+++ b/app/components/UDashboardGroup.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+defineProps<{ unit?: string; ui?: Record<string, any> }>()
+</script>
+
+<template>
+  <div class="flex" :class="ui?.wrapper">
+    <slot />
+  </div>
+</template>
+

--- a/app/components/UDashboardNavbar.vue
+++ b/app/components/UDashboardNavbar.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+defineProps<{ title?: string; ui?: Record<string, any> }>()
+</script>
+
+<template>
+  <header class="flex items-center gap-2 p-4 border-b border-default" :class="ui?.wrapper">
+    <div class="flex items-center gap-2" :class="ui?.leading">
+      <slot name="leading" />
+    </div>
+    <h1 class="flex-1 text-lg font-medium" :class="ui?.title">{{ title }}</h1>
+    <div class="flex items-center gap-2" :class="ui?.right">
+      <slot name="right" />
+      <slot />
+    </div>
+  </header>
+</template>
+

--- a/app/components/UDashboardPanel.vue
+++ b/app/components/UDashboardPanel.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+defineProps<{ id?: string; ui?: Record<string, any> }>()
+</script>
+
+<template>
+  <section :id="id" class="flex flex-col flex-1" :class="ui?.wrapper">
+    <slot />
+  </section>
+</template>
+

--- a/app/components/UDashboardSidebar.vue
+++ b/app/components/UDashboardSidebar.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+defineProps<{ ui?: Record<string, any>; open?: boolean }>()
+
+const collapsed = ref(false)
+</script>
+
+<template>
+  <aside class="flex flex-col" :class="ui?.wrapper">
+    <slot name="header" :collapsed="collapsed" />
+    <div class="flex-1" :class="ui?.content">
+      <slot :collapsed="collapsed" />
+    </div>
+    <div :class="ui?.footer">
+      <slot name="footer" :collapsed="collapsed" />
+    </div>
+  </aside>
+</template>
+

--- a/app/components/UDashboardSidebarCollapse.vue
+++ b/app/components/UDashboardSidebarCollapse.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+const emit = defineEmits(['click'])
+</script>
+
+<template>
+  <UButton
+    icon="i-heroicons-bars-3"
+    variant="ghost"
+    color="gray"
+    size="sm"
+    @click="emit('click')"
+  />
+</template>
+

--- a/app/components/UDashboardToolbar.vue
+++ b/app/components/UDashboardToolbar.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+defineOptions({ inheritAttrs: false })
+defineProps<{ ui?: Record<string, any> }>()
+</script>
+
+<template>
+  <div
+    v-bind="$attrs"
+    class="flex items-center gap-2 p-4 border-b border-default"
+    :class="ui?.wrapper"
+  >
+    <div class="flex items-center gap-2" :class="ui?.left">
+      <slot name="left" />
+    </div>
+    <div class="flex items-center gap-2 ml-auto" :class="ui?.right">
+      <slot />
+    </div>
+  </div>
+</template>
+

--- a/app/stores/linksStore.ts
+++ b/app/stores/linksStore.ts
@@ -228,7 +228,7 @@ export const useLinksStore = defineStore("links", () => {
           id: "source",
           label: "View page source",
           icon: "i-simple-icons-github",
-          to: `https://github.com/nuxt-ui-pro/dashboard/blob/main/app/pages${
+          to: `https://github.com/nuxt/ui/blob/main/app/pages${
             route.path === "/" ? "/index" : route.path
           }.vue`,
           target: "_blank",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,7 @@
 export default defineNuxtConfig({
   modules: [
     "@nuxt/eslint",
-    "@nuxt/ui-pro",
+    "@nuxt/ui",
     "@vueuse/nuxt",
     "@pinia/nuxt", // Pinia module automatically handles Pinia instantiation
   ],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nuxt-ui-pro-template-dashboard",
+  "name": "nuxt-ui-template-dashboard",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- remove Nuxt UI Pro references and switch to free Nuxt UI
- add lightweight dashboard components built on Nuxt UI

## Testing
- `pnpm lint` *(fails: Unexpected trailing comma, etc.)*
- `pnpm typecheck` *(fails: Type errors in stores and nuxt.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68987d8c7e188325a1c122900f2a2aef