### PR TITLE
fix: remove duplicate toast import

### DIFF
--- a/app/composables/useApi.ts
+++ b/app/composables/useApi.ts
@@ -1,6 +1,4 @@
 import { useRouter } from "#app";
-import { toast } from "#build/ui";
-import { color } from "chart.js/helpers";
 
 export function useApi() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- fix duplicate `toast` import in useApi composable

## Testing
- `pnpm lint` *(fails: Unexpected trailing comma, etc.)*
- `pnpm typecheck` *(fails: Could not load @nuxt/ui-pro)*

------
https://chatgpt.com/codex/tasks/task_e_68987d4f485883258eed90f4f52be58f