### PR TITLE
feat: replace pro dashboard components

### DIFF
--- a/app/components/UDashboardNavbar.vue
+++ b/app/components/UDashboardNavbar.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-defineProps<{ title?: string; ui?: Record<string, any> }>()
+defineProps<{
+  title?: string
+  description?: string
+  toggle?: boolean
+  ui?: Record<string, unknown>
+}>()
 </script>
 
 <template>
@@ -7,11 +12,17 @@ defineProps<{ title?: string; ui?: Record<string, any> }>()
     <div class="flex items-center gap-2" :class="ui?.leading">
       <slot name="leading" />
     </div>
-    <h1 class="flex-1 text-lg font-medium" :class="ui?.title">{{ title }}</h1>
+    <div class="flex-1">
+      <h1 class="text-lg font-medium" :class="ui?.title">
+        {{ title }}
+      </h1>
+      <p v-if="description" class="text-sm text-muted" :class="ui?.description">
+        {{ description }}
+      </p>
+    </div>
     <div class="flex items-center gap-2" :class="ui?.right">
       <slot name="right" />
       <slot />
     </div>
   </header>
 </template>
-

--- a/app/components/UDashboardPanel.vue
+++ b/app/components/UDashboardPanel.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
-defineProps<{ id?: string; ui?: Record<string, any> }>()
+defineProps<{ id?: string, ui?: Record<string, unknown> }>()
 </script>
 
 <template>
   <section :id="id" class="flex flex-col flex-1" :class="ui?.wrapper">
-    <slot />
+    <header v-if="$slots.header" :class="ui?.header">
+      <slot name="header" />
+    </header>
+    <div class="flex flex-col flex-1" :class="ui?.body">
+      <slot name="body">
+        <slot />
+      </slot>
+    </div>
   </section>
 </template>
-


### PR DESCRIPTION
## Summary
- render header and body slots in dashboard panel using free components
- support description in dashboard navbar

## Testing
- `pnpm eslint app/components/UDashboardPanel.vue app/components/UDashboardNavbar.vue -f json`
- `pnpm typecheck` *(fails: Property 'json' does not exist on type 'void')*

------
https://chatgpt.com/codex/tasks/task_e_689881ab9548832590ecb4c9a0a5491f