### PR TITLE
fix: enable sidebar burger menu

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -4,7 +4,6 @@ import { ref, onMounted } from 'vue'
 // Initialize the stores
 const linksStore = useLinksStore()
 
-const open = ref(false)
 const links = ref([])
 const groups = ref([])
 // Ensure that permissions are loaded before filtering links
@@ -22,7 +21,6 @@ onMounted(async () => {
     <template #sidebar>
       <UDashboardSidebar
         id="default"
-        v-model:open="open"
         collapsible
         class="bg-elevated/25"
         side="right"
@@ -56,7 +54,11 @@ onMounted(async () => {
     </template>
 
     <template #navbar>
-      <UDashboardNavbar />
+      <UDashboardNavbar>
+        <template #leading>
+          <UDashboardSidebarCollapse />
+        </template>
+      </UDashboardNavbar>
     </template>
 
     <template #default>


### PR DESCRIPTION
## Summary
- add sidebar collapse control to default navbar for burger menu toggle
- drop unused open state from layout

## Testing
- `pnpm lint` *(fails: Strings must use singlequote, Unexpected trailing comma, Extra semicolon)*
- `pnpm typecheck` *(fails: Property 'json' does not exist on type 'void | Response', Object literal may only specify known properties)*

------
https://chatgpt.com/codex/tasks/task_e_689898d2b15c8325924174eaa09af744